### PR TITLE
especificando modelo de rede a ser utilizada

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,8 @@ services:
       - 8000:8000
     env_file:
       - ./env.dev
+    networks:
+      - backend
     depends_on:
       - db
   db:
@@ -20,6 +22,11 @@ services:
       - POSTGRES_USER=dev
       - POSTGRES_PASSWORD=dev
       - POSTGRES_DB=bookstore_db
+    networks:
+      - backend
+networks:
+  backend:
+    driver: bridge
 
 volumes:
   postgres_data:


### PR DESCRIPTION
Neste momento foram adicionadas as configurações necessárias no arquivo `docker-compose.yml` para especificar  o modelo de rede que iremos utilizar no projeto com o Docker
![image_2024-10-05_124714181](https://github.com/user-attachments/assets/cfc090c8-fd1a-4783-83d6-8a4389c3b599)
